### PR TITLE
Add query to check if database is in the wanted version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Ensure the database is migrated to newest version when booting up (Issue 2, wind0r)
+
 ## 1.1.0 - 27. October 2015
 
 * Show a diff between the current commit on the specified target and the

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ and download a packaged version of Applikatoni.
         vim configuration.json
 3. Start the server:
 
-        ./applikatoni -port=":8080" -db=./db/production.db -conf=./configuration.json
+        ./applikatoni -port=:8080 -db=./db/production.db -conf=./configuration.json -env=production
 
 # How it works
 
@@ -227,7 +227,7 @@ Here is a sample `configuration.json` for an application called
 `our-main-application` with its source code hosted under
 `github.com/shipping-company/our-main-application`.
 
-The application will be deployed to three servers: 
+The application will be deployed to three servers:
 
 * 1.unicorn.production.shipping-company.com
 * 2.unicorn.production.shipping-company.com


### PR DESCRIPTION
Added feature as described in #2 .
Maybe some script (build.sh) should check and update the const DBVersion.
Since we do not know which environment we are in and dbconf.yml should not be used the query need to be written by hand.