### PR TITLE
Use markdown for Flowdock notifier message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Use markdown formatting for flowdock notifications (fabrik42)
 * Ensure the database is migrated to newest version when booting up (Issue 2, wind0r)
 
 ## 1.1.0 - 27. October 2015

--- a/server/flowdock_notifier.go
+++ b/server/flowdock_notifier.go
@@ -14,12 +14,13 @@ import (
 	"database/sql"
 )
 
-const summaryTmplStr = `Deployed {{.GitHubRepo}}/{{.Branch}} on {{.Target}} by {{.Username}} :pizza:
+const summaryTmplStr = `New {{.GitHubRepo}} Deployment:
+**{{.Username}}** deployed **{{.Branch}}** on **{{.Target}}** :pizza:
 
-{{.Comment}}
+> {{.Comment}}
 
-SHA: {{.GitHubUrl}}
-URL: {{.DeploymentURL}}
+[View latest commit on GitHub]({{.GitHubUrl}})
+[Open deployment in Applikatoni]({{.DeploymentURL}})
 `
 
 var summaryTemplate = template.Must(template.New("summary").Parse(summaryTmplStr))


### PR DESCRIPTION
Flowdock recently added markdown support to their messages, so we can make the deployment notification a little bit prettier.

It still contains the same amount of information.

I also tried to make the link descriptions a little bit more understandable.

I did not use the "```" code formatting, because this will lead to ugly text highlighting, when entering normal text (which will be likely the case in the comment section).

see http://blog.flowdock.com/2015/08/12/markdown-support-and-an-emoji-picker-are-here/

Before:

![bildschirmfoto 2015-11-15 um 09 33 56](https://cloud.githubusercontent.com/assets/223822/11167991/09e6f6c0-8b7c-11e5-9250-458eb2999ef1.png)

After:

![bildschirmfoto 2015-11-15 um 09 24 00](https://cloud.githubusercontent.com/assets/223822/11167982/a266978a-8b7b-11e5-984d-4ccb927254f9.png)
