### PR TITLE
add footer with version to all pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Add footer (Issue 17, HParker)
 * Stop breaking the layout of deployment overview with long deployment comments (Issue 10, wind0r)
 * Add SHA and link to "what will be deployed"-diff (Issue 11, wind0r)
 * Use markdown formatting for flowdock notifications (fabrik42)

--- a/server/assets/applikatoni.css
+++ b/server/assets/applikatoni.css
@@ -140,5 +140,5 @@ body {
 }
 
 .container .text-muted {
-  margin: 20px 0;
+  margin: 10px 0;
 }

--- a/server/assets/applikatoni.css
+++ b/server/assets/applikatoni.css
@@ -1,3 +1,8 @@
+html {
+  position: relative;
+  min-height: 100%;
+}
+
 .user-controls {
   margin-top: 10px;
   margin-bottom: 10px;
@@ -121,15 +126,19 @@ p.clean {
   font-family: Monospace;
 }
 
-#wrap {
-  min-height: 100%;
-  height: auto;
-  margin: 0 auto -60px;
-  padding: 0 0 60px;
+body {
+  /* Margin bottom by footer height */
+  margin-bottom: 60px;
+}
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  /* Set the fixed height of the footer here */
+  height: 60px;
+  background-color: #f5f5f5;
 }
 
-#footer {
-  padding: 20px;
-  height: 60px;
-  background-color: #f8f8f8;
+.container .text-muted {
+  margin: 20px 0;
 }

--- a/server/assets/applikatoni.css
+++ b/server/assets/applikatoni.css
@@ -120,3 +120,16 @@ p.clean {
   display: inline;
   font-family: Monospace;
 }
+
+#wrap {
+  min-height: 100%;
+  height: auto;
+  margin: 0 auto -60px;
+  padding: 0 0 60px;
+}
+
+#footer {
+  padding: 20px;
+  height: 60px;
+  background-color: #f8f8f8;
+}

--- a/server/assets/templates/layout.tmpl
+++ b/server/assets/templates/layout.tmpl
@@ -46,8 +46,10 @@
       </div>
     <footer class="footer navbar-fixed-bottom">
       <div class="container">
-        <p class="text-muted">
-          <a href="http://applikatoni.com/">Applikatoni</a> {{ .Version }} © <a href="https://flinc.org/">flinc</a> 2015.
+        <p class="text-muted text-center">
+          <a href="http://applikatoni.com/">Applikatoni</a> {{ .Version }}
+          <br>
+          © <a href="https://flinc.org/">flinc</a> 2015.
         </p>
       </div>
     </footer>

--- a/server/assets/templates/layout.tmpl
+++ b/server/assets/templates/layout.tmpl
@@ -17,33 +17,42 @@
     <link rel="stylesheet" href="/assets/applikatoni.css">
   </head>
   <body>
-    <nav class="navbar navbar-default navbar-static-top">
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <a class="navbar-brand" href="/">Applikatoni</a>
-        </div>
+    <div id="wrap">
+      <nav class="navbar navbar-default navbar-static-top">
+        <div class="container-fluid">
+          <div class="navbar-header">
+            <a class="navbar-brand" href="/">Applikatoni</a>
+          </div>
 
-        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-          {{ if .currentUser }}
-            {{template "applicationsNavbar" .}}
-          {{end}}
-
-          <p class="nav navbar-text navbar-right user-controls">
+          <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             {{ if .currentUser }}
+            {{template "applicationsNavbar" .}}
+            {{end}}
+
+            <p class="nav navbar-text navbar-right user-controls">
+              {{ if .currentUser }}
               <img src="{{ .currentUser.AvatarUrl }}" class="img-circle avatar">
               <b>{{ .currentUser.Name }}</b>
               <a href="/oauth2/logout" class="navbar-link">Log out</a>
-            {{ else }}
+              {{ else }}
               <a href="/oauth2/authorize" class="btn btn-default btn-sm navbar-link login">Login With GitHub</a>
-            {{ end }}
-          </p>
+              {{ end }}
+            </p>
+          </div>
         </div>
-      </div>
-    </nav>
+      </nav>
 
-    <div class="container">
-      {{template "body" .}}
+      <div class="container">
+        {{template "body" .}}
+      </div>
     </div>
+    <footer id="footer" class="navbar-fixed-bottom">
+      <div class="container">
+        <p class="text-muted">
+          <a href="http://applikatoni.com/">Applikatoni</a> {{ .Version }} © <a href="https://flinc.org/">flinc</a> 2015.
+        </p>
+      </div>
+    </footer>
 
     {{template "hoganTemplates"}}
 

--- a/server/assets/templates/layout.tmpl
+++ b/server/assets/templates/layout.tmpl
@@ -17,33 +17,33 @@
     <link rel="stylesheet" href="/assets/applikatoni.css">
   </head>
   <body>
-      <nav class="navbar navbar-default navbar-static-top">
-        <div class="container-fluid">
-          <div class="navbar-header">
-            <a class="navbar-brand" href="/">Applikatoni</a>
-          </div>
-
-          <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-            {{ if .currentUser }}
-            {{template "applicationsNavbar" .}}
-            {{end}}
-
-            <p class="nav navbar-text navbar-right user-controls">
-              {{ if .currentUser }}
-              <img src="{{ .currentUser.AvatarUrl }}" class="img-circle avatar">
-              <b>{{ .currentUser.Name }}</b>
-              <a href="/oauth2/logout" class="navbar-link">Log out</a>
-              {{ else }}
-              <a href="/oauth2/authorize" class="btn btn-default btn-sm navbar-link login">Login With GitHub</a>
-              {{ end }}
-            </p>
-          </div>
+    <nav class="navbar navbar-default navbar-static-top">
+      <div class="container-fluid">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="/">Applikatoni</a>
         </div>
-      </nav>
 
-      <div class="container">
-        {{template "body" .}}
+        <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+          {{ if .currentUser }}
+          {{template "applicationsNavbar" .}}
+          {{end}}
+
+          <p class="nav navbar-text navbar-right user-controls">
+            {{ if .currentUser }}
+            <img src="{{ .currentUser.AvatarUrl }}" class="img-circle avatar">
+            <b>{{ .currentUser.Name }}</b>
+            <a href="/oauth2/logout" class="navbar-link">Log out</a>
+            {{ else }}
+            <a href="/oauth2/authorize" class="btn btn-default btn-sm navbar-link login">Login With GitHub</a>
+            {{ end }}
+          </p>
+        </div>
       </div>
+    </nav>
+
+    <div class="container">
+      {{template "body" .}}
+    </div>
     <footer class="footer navbar-fixed-bottom">
       <div class="container">
         <p class="text-muted text-center">

--- a/server/assets/templates/layout.tmpl
+++ b/server/assets/templates/layout.tmpl
@@ -17,7 +17,6 @@
     <link rel="stylesheet" href="/assets/applikatoni.css">
   </head>
   <body>
-    <div id="wrap">
       <nav class="navbar navbar-default navbar-static-top">
         <div class="container-fluid">
           <div class="navbar-header">
@@ -45,7 +44,6 @@
       <div class="container">
         {{template "body" .}}
       </div>
-    </div>
     <footer class="footer navbar-fixed-bottom">
       <div class="container">
         <p class="text-muted">

--- a/server/assets/templates/layout.tmpl
+++ b/server/assets/templates/layout.tmpl
@@ -46,7 +46,7 @@
         {{template "body" .}}
       </div>
     </div>
-    <footer id="footer" class="navbar-fixed-bottom">
+    <footer class="footer navbar-fixed-bottom">
       <div class="container">
         <p class="text-muted">
           <a href="http://applikatoni.com/">Applikatoni</a> {{ .Version }} © <a href="https://flinc.org/">flinc</a> 2015.

--- a/server/templates.go
+++ b/server/templates.go
@@ -56,6 +56,8 @@ func renderTemplate(w http.ResponseWriter, name string, data map[string]interfac
 		return
 	}
 
+	data["Version"] = VERSION
+
 	err := tmpl.Execute(w, data)
 	if err != nil {
 		log.Printf("rendering %s failed: %s\n", name, err)


### PR DESCRIPTION
<img width="1440" alt="screen shot 2015-12-01 at 11 35 57 pm" src="https://cloud.githubusercontent.com/assets/4482399/11524117/336694ae-9885-11e5-8a11-f7da28779a63.png">

Added a footer as per issue #17 

I think it looks nice and it should always have the right version number and stay at the bottom of the page. Let me know if you have any ideas/improvements.
