### PR TITLE
Introduce Deployment Notifiers - Use higher order function to refactor notifiers

### DIFF
--- a/server/bugsnag_notifier.go
+++ b/server/bugsnag_notifier.go
@@ -5,40 +5,17 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/applikatoni/applikatoni/deploy"
 	"github.com/applikatoni/applikatoni/models"
-
-	"database/sql"
 )
 
 const (
 	bugsnagNotifyEndpoint = "https://notify.bugsnag.com/deploy"
 )
 
-func NotifyBugsnag(db *sql.DB, endpoint string, deploymentId int) {
-	deployment, err := getDeployment(db, deploymentId)
-	if err != nil {
-		log.Printf("Could not find deployment with id %v, %s\n", deploymentId, err)
-		return
+func NotifyBugsnag(ev *DeploymentEvent) {
+	if ev.Target.BugsnagApiKey != "" {
+		SendBugsnagRequest(bugsnagNotifyEndpoint, ev.Deployment, ev.Target, ev.Application)
 	}
-
-	application, err := findApplication(deployment.ApplicationName)
-	if err != nil {
-		log.Printf("Could not find application with name %v, %s\n", deployment.ApplicationName, err)
-		return
-	}
-
-	target, err := findTarget(application, deployment.TargetName)
-	if err != nil {
-		log.Printf("Could not find target with name %v, %s\n", deployment.TargetName, err)
-		return
-	}
-
-	if target.BugsnagApiKey == "" {
-		return
-	}
-
-	SendBugsnagRequest(bugsnagNotifyEndpoint, deployment, target, application)
 }
 
 func SendBugsnagRequest(endpoint string, d *models.Deployment, t *models.Target, a *models.Application) {
@@ -64,16 +41,4 @@ func SendBugsnagRequest(endpoint string, d *models.Deployment, t *models.Target,
 
 	log.Printf("Successfully notified Bugsnag about deployment of %s on %s, %s!\n",
 		d.ApplicationName, d.TargetName, d.CommitSha)
-}
-
-func newBugsnagNotifier(db *sql.DB) deploy.Listener {
-	fn := func(logs <-chan deploy.LogEntry) {
-		for entry := range logs {
-			if entry.EntryType == deploy.DEPLOYMENT_SUCCESS {
-				go NotifyBugsnag(db, bugsnagNotifyEndpoint, entry.DeploymentId)
-			}
-		}
-	}
-
-	return fn
 }

--- a/server/flowdock_notifier.go
+++ b/server/flowdock_notifier.go
@@ -6,10 +6,7 @@ import (
 	"net/url"
 	"text/template"
 
-	"github.com/applikatoni/applikatoni/deploy"
 	"github.com/applikatoni/applikatoni/models"
-
-	"database/sql"
 )
 
 const flowdockTmplStr = `{{.GitHubRepo}} {{if .Success}}Successfully Deployed{{else}}Deploy Failed{{end}}:
@@ -23,42 +20,18 @@ const flowdockTmplStr = `{{.GitHubRepo}} {{if .Success}}Successfully Deployed{{e
 
 var flowdockTemplate = template.Must(template.New("flowdockSummary").Parse(flowdockTmplStr))
 
-func NotifyFlowdock(db *sql.DB, entry deploy.LogEntry) {
-	deployment, err := getDeployment(db, entry.DeploymentId)
-	if err != nil {
-		log.Printf("Could not find deployment with id %v, %s\n", entry.DeploymentId, err)
+func NotifyFlowdock(ev *DeploymentEvent) {
+	if ev.Target.FlowdockEndpoint == "" {
 		return
 	}
 
-	application, err := findApplication(deployment.ApplicationName)
-	if err != nil {
-		log.Printf("Could not find application with name %v, %s\n", deployment.ApplicationName, err)
-		return
-	}
-
-	target, err := findTarget(application, deployment.TargetName)
-	if err != nil {
-		log.Printf("Could not find target with name %v, %s\n", deployment.TargetName, err)
-		return
-	}
-
-	if target.FlowdockEndpoint == "" {
-		return
-	}
-
-	user, err := getUser(db, deployment.UserId)
-	if err != nil {
-		log.Printf("Could not find User with id %v, %s\n", deployment.UserId, err)
-		return
-	}
-
-	summary, err := generateSummary(flowdockTemplate, entry, application, deployment, user)
+	summary, err := generateSummary(flowdockTemplate, ev.Entry, ev.Application, ev.Deployment, ev.User)
 	if err != nil {
 		log.Printf("Could not generate deployment summary, %s\n", err)
 		return
 	}
 
-	SendFlowdockRequest(target.FlowdockEndpoint, deployment, summary)
+	SendFlowdockRequest(ev.Target.FlowdockEndpoint, ev.Deployment, summary)
 }
 
 func SendFlowdockRequest(endpoint string, d *models.Deployment, summary string) {
@@ -82,16 +55,4 @@ func SendFlowdockRequest(endpoint string, d *models.Deployment, summary string) 
 
 	log.Printf("Successfully notified Flowdock about deployment of %s on %s, %s!\n",
 		d.ApplicationName, d.TargetName, d.CommitSha)
-}
-
-func newFlowdockNotifier(db *sql.DB) deploy.Listener {
-	fn := func(logs <-chan deploy.LogEntry) {
-		for entry := range logs {
-			if entry.EntryType == deploy.DEPLOYMENT_SUCCESS || entry.EntryType == deploy.DEPLOYMENT_FAIL {
-				go NotifyFlowdock(db, entry)
-			}
-		}
-	}
-
-	return fn
 }

--- a/server/main.go
+++ b/server/main.go
@@ -147,16 +147,30 @@ func main() {
 	logRouter.SubscribeAll(deploy.ConsoleLogger)
 	// Setup the listener that persists all log entries
 	logRouter.SubscribeAll(newLogEntrySaver(db))
-	// Setup the bugsnag deployment tracking
-	logRouter.SubscribeAll(newBugsnagNotifier(db))
-	// Setup the flowdock deployment notifcation
-	logRouter.SubscribeAll(newFlowdockNotifier(db))
-	// Setup the new relic deployment notifcation
-	logRouter.SubscribeAll(newNewRelicNotifier(db))
-	// Setup the Slack deployment notifcation
-	logRouter.SubscribeAll(newSlackNotifier(db))
-	// Setup the Webhook notifcation
+	// Setup the Webhook notification
 	logRouter.SubscribeAll(newWebHookNotifier(db))
+	// Setup the bugsnag deployment tracking
+	bugsnag := NewDeploymentListener(db, NotifyBugsnag, []deploy.LogEntryType{
+		deploy.DEPLOYMENT_SUCCESS,
+	})
+	logRouter.SubscribeAll(bugsnag)
+	// Setup the new relic deployment notifcation
+	newRelic := NewDeploymentListener(db, NotifyNewRelic, []deploy.LogEntryType{
+		deploy.DEPLOYMENT_SUCCESS,
+	})
+	logRouter.SubscribeAll(newRelic)
+	// Setup the flowdock deployment notifcation
+	flowdock := NewDeploymentListener(db, NotifyFlowdock, []deploy.LogEntryType{
+		deploy.DEPLOYMENT_FAIL,
+		deploy.DEPLOYMENT_SUCCESS,
+	})
+	logRouter.SubscribeAll(flowdock)
+	// Setup the Slack deployment notifcation
+	slack := NewDeploymentListener(db, NotifySlack, []deploy.LogEntryType{
+		deploy.DEPLOYMENT_FAIL,
+		deploy.DEPLOYMENT_SUCCESS,
+	})
+	logRouter.SubscribeAll(slack)
 
 	// Setup the router and the routes
 	r := mux.NewRouter()

--- a/server/notifier.go
+++ b/server/notifier.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+
+	"github.com/applikatoni/applikatoni/deploy"
+	"github.com/applikatoni/applikatoni/models"
+)
+
+type DeploymentEvent struct {
+	Entry       deploy.LogEntry
+	Deployment  *models.Deployment
+	Application *models.Application
+	Target      *models.Target
+	User        *models.User
+}
+
+type DeploymentNotifier func(*DeploymentEvent)
+
+func NewDeploymentEvent(e deploy.LogEntry) (*DeploymentEvent, error) {
+	deployment, err := getDeployment(db, e.DeploymentId)
+	if err != nil {
+		err = fmt.Errorf("Could not find deployment with id %d, %s\n", e.DeploymentId, err)
+		return nil, err
+	}
+
+	application, err := findApplication(deployment.ApplicationName)
+	if err != nil {
+		err = fmt.Errorf("Could not find application with name %q, %s\n", deployment.ApplicationName, err)
+		return nil, err
+	}
+
+	target, err := findTarget(application, deployment.TargetName)
+	if err != nil {
+		err = fmt.Errorf("Could not find target with name %q, %s\n", deployment.TargetName, err)
+		return nil, err
+	}
+
+	user, err := getUser(db, deployment.UserId)
+	if err != nil {
+		err = fmt.Errorf("Could not find User with id %id, %s\n", deployment.UserId, err)
+		return nil, err
+	}
+
+	event := &DeploymentEvent{
+		Entry:       e,
+		Deployment:  deployment,
+		Application: application,
+		Target:      target,
+		User:        user,
+	}
+
+	return event, nil
+}
+
+func NewDeploymentListener(db *sql.DB, fn DeploymentNotifier, evs []deploy.LogEntryType) deploy.Listener {
+	return func(logs <-chan deploy.LogEntry) {
+		for entry := range logs {
+			for _, entryType := range evs {
+				if entry.EntryType != entryType {
+					continue
+				}
+
+				go func() {
+					event, err := NewDeploymentEvent(entry)
+					if err != nil {
+						log.Printf("Not calling success notifier. error=%s\n", err)
+						return
+					}
+
+					fn(event)
+				}()
+			}
+		}
+	}
+}

--- a/server/notifier.go
+++ b/server/notifier.go
@@ -17,8 +17,6 @@ type DeploymentEvent struct {
 	User        *models.User
 }
 
-type DeploymentNotifier func(*DeploymentEvent)
-
 func NewDeploymentEvent(e deploy.LogEntry) (*DeploymentEvent, error) {
 	deployment, err := getDeployment(db, e.DeploymentId)
 	if err != nil {
@@ -55,7 +53,9 @@ func NewDeploymentEvent(e deploy.LogEntry) (*DeploymentEvent, error) {
 	return event, nil
 }
 
-func NewDeploymentListener(db *sql.DB, fn DeploymentNotifier, evs []deploy.LogEntryType) deploy.Listener {
+type Notifier func(*DeploymentEvent)
+
+func NewDeploymentListener(db *sql.DB, fn Notifier, evs []deploy.LogEntryType) deploy.Listener {
 	return func(logs <-chan deploy.LogEntry) {
 		for entry := range logs {
 			for _, entryType := range evs {

--- a/server/notifier.go
+++ b/server/notifier.go
@@ -66,7 +66,7 @@ func NewDeploymentListener(db *sql.DB, fn Notifier, evs []deploy.LogEntryType) d
 				go func() {
 					event, err := NewDeploymentEvent(entry)
 					if err != nil {
-						log.Printf("Not calling success notifier. error=%s\n", err)
+						log.Printf("Error creating DeploymentEvent. error=%s\n", err)
 						return
 					}
 

--- a/server/notifier.go
+++ b/server/notifier.go
@@ -38,7 +38,7 @@ func NewDeploymentEvent(e deploy.LogEntry) (*DeploymentEvent, error) {
 
 	user, err := getUser(db, deployment.UserId)
 	if err != nil {
-		err = fmt.Errorf("Could not find User with id %id, %s\n", deployment.UserId, err)
+		err = fmt.Errorf("Could not find User with id %d, %s\n", deployment.UserId, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
I need some more eyeballs on this.

With this we change the existing Notifiers to be merely a `Notifier` and not `deploy.Listener`. Instead we use a higher-order function called `NewDeploymentListener` that turns a `Notifier` into a `Listener` that then calls the original `Notifier` with a `DeploymentEvent`.

I'm still not sure about the file organisation.