### PR TITLE
Add support for Mailgun to send daily digest emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add [Mailgun](https://mailgun.com) support for daily digest emails. Users can
+  now choose between Mailgun and Mandrill. Mailgun has priority in the
+  configuration. (PR 37, mrnugget)
 * Fix the indentation of multi-line deployment comments in Flowdock summary (mrnugget)
 * **BREAKING CHANGE**: fix unstable webhooks and "database is locked" errors by
   reducing the amount of webhook triggers. Webhooks now only receive a maximum

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Unicorn webserver and Sidekiq as a background worker process.
   "github_client_id": "<CLIENT_ID>",
   "github_client_secret": "<CLIENT_SECRET>",
   "mandrill_api_key": "<API_KEY>",
+  "mailgun_base_url": "<MAILGUN_BASE_URL>",
+  "mailgun_api_key": "<API_KEY>",
   "applications": [
     {
       "name": "our-main-application",
@@ -349,9 +351,8 @@ Unicorn webserver and Sidekiq as a background worker process.
   Applikatoni instance is the one specified at GitHub.
 * `github_client_id` - The client ID from your GitHub OAuth2 application.
 * `github_client_secret` - The client secret from your GitHub OAuth2 application.
-* `mandrill_api_key` - The API key of your [Mandrill](https://mandrillapp.com/)
-  account. This is needed to send daily digest emails. If this is blank or left
-out, no daily digest email will be sent.
+* `mandrill_api_key` - The API key of your [Mandrill](https://mandrillapp.com/) account. Optional, but this is needed to send daily digest emails. If this is blank or left out, no daily digest email will be sent.
+* `mailgun_base_url` and `mailgun_api_key` - The base URL and API key of your [Mailgun](https://mailgun.com/) account. Optional, but this is needed to send daily digest emails. If this is blank or left out, the configuration is checked for Mandrill credentials, if none are found, no daily digest email will be sent.
 * `applications` - An array of application configurations that Applikatoni can deploy.
 
 ### Application Properties
@@ -364,7 +365,7 @@ Inside the `applications` array applications need to be configured.
 * `github_repo` - The name of the GitHub repository. It's the `rails-app` in `github.com/company/rails-app`.
 * `github_branches` - An array of branch names. These branches will show up with their current status on the application page in Applikatoni to easily deploy them with a click.
 * `travis_image_url` - The URL to the [Travis CI status image](http://docs.travis-ci.com/user/status-images/), including the token.
-* `daily_digest_receivers` - An array of email addresses to which the daily digest should be sent (if `mandrill_api_key` is not set, no daily digest will be sent).
+* `daily_digest_receivers` - An array of email addresses to which the daily digest should be sent (if `mandrill_api_key` or `mailgun_base_url` and `mailgun_api_key` are not set, no daily digest will be sent).
 * `daily_digest_target` - The name of the `target` for which the daily digest should be sent. For example: if you have `test`, `staging` and `production` targets, it makes sense to only send out daily digest emails for `production`.
 
 ### Target Properties

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -20,6 +20,16 @@ type Configuration struct {
 	Applications       []*models.Application `json:"applications"`
 }
 
+func (c *Configuration) DailyDigestSender() DailyDigestSender {
+	if c.MailgunBaseURL != "" && c.MailgunAPIKey != "" {
+		return NewMailgunClient(c.MailgunBaseURL, c.MailgunAPIKey)
+	} else if c.MandrillAPIKey != "" {
+		return NewMandrillClient(mandrillMessagesEndpoint, c.MandrillAPIKey)
+	} else {
+		return nil
+	}
+}
+
 func readConfiguration(path string) (*Configuration, error) {
 	var config Configuration
 

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -15,6 +15,8 @@ type Configuration struct {
 	GitHubClientId     string                `json:"github_client_id"`
 	GitHubClientSecret string                `json:"github_client_secret"`
 	MandrillAPIKey     string                `json:"mandrill_api_key"`
+	MailgunBaseURL     string                `json:"mailgun_base_url"`
+	MailgunAPIKey      string                `json:"mailgun_api_key"`
 	Applications       []*models.Application `json:"applications"`
 }
 

--- a/server/mailgun.go
+++ b/server/mailgun.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type MailgunClient struct {
+	*http.Client
+	baseUrl string
+	apiKey  string
+}
+
+func NewMailgunClient(baseUrl, apiKey string) *MailgunClient {
+	return &MailgunClient{
+		Client:  &http.Client{},
+		baseUrl: baseUrl,
+		apiKey:  apiKey,
+	}
+}
+
+func (m *MailgunClient) SendDigest(digest *DailyDigest) error {
+	params := url.Values{
+		"from":    {fmt.Sprintf("%s <%s>", digestFromName, digestFromEmail)},
+		"to":      {strings.Join(digest.Receivers, ",")},
+		"subject": {digest.Subject},
+		"text":    {digest.TextBody.String()},
+		"html":    {digest.HtmlBody.String()},
+	}
+
+	requestBody := strings.NewReader(params.Encode())
+	requestUrl := fmt.Sprintf("%s/messages", m.baseUrl)
+
+	req, err := http.NewRequest("POST", requestUrl, requestBody)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("api", m.apiKey)
+
+	resp, err := m.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("mailgun status code not 200. got=%d", resp.StatusCode)
+	}
+
+	return nil
+}

--- a/server/mailgun.go
+++ b/server/mailgun.go
@@ -9,14 +9,14 @@ import (
 
 type MailgunClient struct {
 	*http.Client
-	baseUrl string
+	baseURL string
 	apiKey  string
 }
 
-func NewMailgunClient(baseUrl, apiKey string) *MailgunClient {
+func NewMailgunClient(baseURL, apiKey string) *MailgunClient {
 	return &MailgunClient{
 		Client:  &http.Client{},
-		baseUrl: baseUrl,
+		baseURL: baseURL,
 		apiKey:  apiKey,
 	}
 }
@@ -31,7 +31,7 @@ func (m *MailgunClient) SendDigest(digest *DailyDigest) error {
 	}
 
 	requestBody := strings.NewReader(params.Encode())
-	requestUrl := fmt.Sprintf("%s/messages", m.baseUrl)
+	requestUrl := fmt.Sprintf("%s/messages", m.baseURL)
 
 	req, err := http.NewRequest("POST", requestUrl, requestBody)
 	if err != nil {

--- a/server/mailgun_test.go
+++ b/server/mailgun_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-func TestSendDigest(t *testing.T) {
+func TestMailgunSendDigest(t *testing.T) {
 	var digestHtmlBody bytes.Buffer
 	digestHtmlBody.WriteString("<h1>Hello there!")
 

--- a/server/mailgun_test.go
+++ b/server/mailgun_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSendDigest(t *testing.T) {
+	var digestHtmlBody bytes.Buffer
+	digestHtmlBody.WriteString("<h1>Hello there!")
+
+	var digestTextBody bytes.Buffer
+	digestTextBody.WriteString("Hello there!")
+
+	digest := &DailyDigest{
+		FromName:  digestFromName,
+		FromEmail: digestFromEmail,
+		Subject:   "foobar",
+		Receivers: []string{"mrnugget@gmail.com"},
+		TextBody:  digestTextBody,
+		HtmlBody:  digestHtmlBody,
+	}
+
+	tests := []struct {
+		formKey  string
+		expected string
+	}{
+		{"from", fmt.Sprintf("%s <%s>", digestFromName, digestFromEmail)},
+		{"to", strings.Join(digest.Receivers, ",")},
+		{"subject", digest.Subject},
+		{"text", digestTextBody.String()},
+		{"html", digestHtmlBody.String()},
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, tt := range tests {
+			actual := r.FormValue(tt.formKey)
+			if actual != tt.expected {
+				t.Errorf("sent wrong value for %s. want=%s, got=%s", tt.formKey, tt.expected, actual)
+			}
+		}
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	mailgun := NewMailgunClient(ts.URL, "foobarapikey")
+	err := mailgun.SendDigest(digest)
+	if err != nil {
+		t.Errorf("SendDigest error: %s", err)
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -136,7 +136,10 @@ func main() {
 	killRegistry = NewKillRegistry()
 
 	// Run the daily digest sending in the background
-	go SendDailyDigests(db)
+	digestSender := config.DailyDigestSender()
+	if digestSender != nil {
+		go SendDailyDigests(db, digestSender)
+	}
 
 	// Setup session store
 	sessionStore = sessions.NewCookieStore([]byte(config.SessionSecret))

--- a/server/mandrill.go
+++ b/server/mandrill.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"log"
+	"io"
 	"net/http"
 )
 
@@ -47,6 +47,25 @@ func NewMandrillClient(endpoint, apiKey string) *MandrillClient {
 }
 
 func (m *MandrillClient) SendDigest(digest *DailyDigest) error {
+	requestBody, err := m.newRequestBody(digest)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", m.endpoint, requestBody)
+	if err != nil {
+		return err
+	}
+
+	resp, err := m.Do(req)
+	if err != nil {
+		return err
+	}
+
+	return m.checkResponseStatus(resp)
+}
+
+func (m *MandrillClient) newRequestBody(digest *DailyDigest) (io.Reader, error) {
 	to := []MandrillReceiver{}
 	for _, email := range digest.Receivers {
 		to = append(to, MandrillReceiver{email})
@@ -65,31 +84,28 @@ func (m *MandrillClient) SendDigest(digest *DailyDigest) error {
 
 	data, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", m.endpoint, bytes.NewReader(data))
-	if err != nil {
-		return err
-	}
+	return bytes.NewReader(data), nil
+}
 
-	resp, err := m.Do(req)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("mandrill response code not 200, but %d", resp.StatusCode)
+func (m *MandrillClient) checkResponseStatus(response *http.Response) error {
+	if response.StatusCode != 200 {
+		return fmt.Errorf("mandrill response code is %d", response.StatusCode)
 	}
 
 	responseBody := []MandrillDeliveryStatus{}
-	err = json.NewDecoder(resp.Body).Decode(&responseBody)
+	err := json.NewDecoder(response.Body).Decode(&responseBody)
 	if err != nil {
 		return err
 	}
 
 	for _, delivery := range responseBody {
 		if delivery.Status != "sent" {
-			log.Printf("sending email to %s failed. delivery status: %s", delivery.Email, delivery.Status)
+			err := fmt.Errorf("Sending digest to %s failed. delivery status=%s",
+				delivery.Email, delivery.Status)
+			return err
 		}
 	}
 

--- a/server/mandrill_test.go
+++ b/server/mandrill_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestMandrillSendDigest(t *testing.T) {
+	var digestHtmlBody bytes.Buffer
+	digestHtmlBody.WriteString("<h1>Hello there!")
+
+	var digestTextBody bytes.Buffer
+	digestTextBody.WriteString("Hello there!")
+
+	digest := &DailyDigest{
+		FromName:  digestFromName,
+		FromEmail: digestFromEmail,
+		Subject:   "foobar",
+		Receivers: []string{"mrnugget@gmail.com"},
+		TextBody:  digestTextBody,
+		HtmlBody:  digestHtmlBody,
+	}
+
+	writeFakeResponse := func(w http.ResponseWriter) {
+		fakeResponse := []MandrillDeliveryStatus{
+			{Email: digest.Receivers[0], Status: "sent"},
+		}
+		js, err := json.Marshal(fakeResponse)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(200)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(js)
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPayload := &MandrillMessagePayload{}
+
+		err := json.NewDecoder(r.Body).Decode(receivedPayload)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if receivedPayload.Key != "mandrillapikey" {
+			t.Errorf("received wrong api key. got=%s", receivedPayload.Key)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.To[0].Email != digest.Receivers[0] {
+			t.Errorf("wrong receivers. got=%+v", receivedPayload.Message.To)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.FromEmail != digestFromEmail {
+			t.Errorf("FromMail wrong. got=%s", receivedPayload.Message.FromEmail)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.FromName != digestFromName {
+			t.Errorf("FromName wrong. got=%s", receivedPayload.Message.FromName)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.Subject != digest.Subject {
+			t.Errorf("Subject wrong. got=%s", receivedPayload.Message.Subject)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.Text != digest.TextBody.String() {
+			t.Errorf("Text wrong. got=%s", receivedPayload.Message.Text)
+			w.WriteHeader(500)
+			return
+		}
+		if receivedPayload.Message.Html != digest.HtmlBody.String() {
+			t.Errorf("Html wrong. got=%s", receivedPayload.Message.Html)
+			w.WriteHeader(500)
+			return
+		}
+
+		writeFakeResponse(w)
+	}))
+	defer ts.Close()
+
+	mandrill := NewMandrillClient(ts.URL, "mandrillapikey")
+	err := mandrill.SendDigest(digest)
+	if err != nil {
+		t.Errorf("SendDigest error: %s", err)
+	}
+}


### PR DESCRIPTION
Since I'm cheap and [Mailchimp is going to require paid Mailchimp accounts for using Mandrill](http://blog.mailchimp.com/important-changes-to-mandrill/) I wanted to add [Mailgun](https://mailgun.com) support.

Well, it's done. The `configuration.json` now supports `mailgun_base_url` and `mailgun_api_key` keys. If these are given, the Mailgun client is used to send daily digest emails. If they don't exist the configuration is checked for the Mandrill api key, exactly as before.