### PR TITLE
Use GitHub Deployments API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Add support for the GitHub deployments API. Creating a new deployment now
+  also creates a new GitHub deployment and the status is updated accordingly.
+  (mrnugget)
 * Add [Mailgun](https://mailgun.com) support for daily digest emails. Users can
   now choose between Mailgun and Mandrill. Mailgun has priority in the
   configuration. (PR 37, mrnugget)

--- a/server/deployment_event_hub.go
+++ b/server/deployment_event_hub.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 
 	"github.com/applikatoni/applikatoni/models"
@@ -13,6 +14,18 @@ type DeploymentEvent struct {
 	Application *models.Application
 	Target      *models.Target
 	User        *models.User
+}
+
+func (de *DeploymentEvent) DeploymentURL() string {
+	var scheme string
+	if config.SSLEnabled {
+		scheme = "https"
+	} else {
+		scheme = "http"
+	}
+
+	return fmt.Sprintf("%s://%s/%v/deployments/%v", scheme, config.Host,
+		de.Application.GitHubRepo, de.Deployment.Id)
 }
 
 type Subscriber func(*DeploymentEvent)

--- a/server/deployment_event_hub_test.go
+++ b/server/deployment_event_hub_test.go
@@ -76,3 +76,43 @@ func TestPublish(t *testing.T) {
 
 	<-testDone
 }
+
+func TestDeploymentEventDeploymentURL(t *testing.T) {
+	config = &Configuration{
+		Host:       "example.com",
+		SSLEnabled: true,
+	}
+
+	deployment := &models.Deployment{
+		Id:              999999,
+		UserId:          888888,
+		CommitSha:       "f133742",
+		Branch:          "master",
+		Comment:         "Deploying a hotfix",
+		ApplicationName: "my-web-app",
+		TargetName:      "production",
+	}
+	user := &models.User{
+		Name: "mrnugget",
+		Id:   deployment.UserId,
+	}
+	target := &models.Target{Name: "production"}
+	application := &models.Application{
+		Name:        "my-web-app",
+		GitHubRepo:  "my-web-app",
+		GitHubOwner: "shipping-co",
+	}
+
+	event := &DeploymentEvent{
+		State:       models.DEPLOYMENT_SUCCESSFUL,
+		Deployment:  deployment,
+		Application: application,
+		Target:      target,
+		User:        user,
+	}
+
+	deploymentURL := event.DeploymentURL()
+	if deploymentURL != "https://example.com/my-web-app/deployments/999999" {
+		t.Errorf("DeploymentURL() returned wrong url. got=%q", deploymentURL)
+	}
+}

--- a/server/github.go
+++ b/server/github.go
@@ -58,6 +58,13 @@ type GitHubDiff struct {
 	Commits          []GitHubCommit `json:"commits"`
 }
 
+type GitHubDeployment struct {
+	Id          int64  `json:"id"`
+	Sha         string `json:"sha"`
+	Environment string `json:"environment"`
+	StatusesURL string `json:"statuses_url"`
+}
+
 type GitHubClient struct{ *http.Client }
 
 func NewGitHubClient(u *models.User) *GitHubClient {
@@ -149,13 +156,6 @@ func (gc *GitHubClient) UpdateUser(u *models.User) error {
 
 	err := gc.GetDecode(url, u)
 	return err
-}
-
-type GitHubDeployment struct {
-	Id          int64  `json:"id"`
-	Sha         string `json:"sha"`
-	Environment string `json:"environment"`
-	StatusesURL string `json:"statuses_url"`
 }
 
 func (gc *GitHubClient) CreateDeployment(a *models.Application, d *models.Deployment) (*GitHubDeployment, error) {

--- a/server/github.go
+++ b/server/github.go
@@ -65,6 +65,11 @@ type GitHubDeployment struct {
 	StatusesURL string `json:"statuses_url"`
 }
 
+type GitHubDeploymentStatus struct {
+	State     string `json:"state"`
+	TargetURL string `json:"target_url"`
+}
+
 type GitHubClient struct{ *http.Client }
 
 func NewGitHubClient(u *models.User) *GitHubClient {
@@ -199,26 +204,13 @@ func (gc *GitHubClient) CreateDeployment(a *models.Application, d *models.Deploy
 	return githubDeployment, nil
 }
 
-func (gc *GitHubClient) CreateDeploymentStatus(d *GitHubDeployment, state models.DeploymentState) error {
-	createDeploymentStatusPayload := struct {
-		State string `json:"state"`
-	}{}
-
-	switch state {
-	case models.DEPLOYMENT_ACTIVE:
-		createDeploymentStatusPayload.State = "pending"
-	case models.DEPLOYMENT_SUCCESSFUL:
-		createDeploymentStatusPayload.State = "success"
-	case models.DEPLOYMENT_FAILED:
-		createDeploymentStatusPayload.State = "failure"
-	}
-
-	jsonPayload, err := json.Marshal(createDeploymentStatusPayload)
+func (gc *GitHubClient) CreateDeploymentStatus(statusesURL string, status *GitHubDeploymentStatus) error {
+	jsonPayload, err := json.Marshal(status)
 	if err != nil {
 		return err
 	}
 
-	resp, err := gc.Post(d.StatusesURL, "application/json", bytes.NewBuffer(jsonPayload))
+	resp, err := gc.Post(statusesURL, "application/json", bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return err
 	}

--- a/server/github_notifier.go
+++ b/server/github_notifier.go
@@ -7,9 +7,6 @@ import (
 	"github.com/applikatoni/applikatoni/models"
 )
 
-var githubDeployments map[int]*GitHubDeployment
-var githubDeploymentsMutex *sync.Mutex
-
 type GitHubNotifier struct {
 	deployments map[int]*GitHubDeployment
 	mutex       *sync.Mutex

--- a/server/github_notifier.go
+++ b/server/github_notifier.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"log"
+	"sync"
+
+	"github.com/applikatoni/applikatoni/models"
+)
+
+var githubDeployments map[int]*GitHubDeployment
+var githubDeploymentsMutex *sync.Mutex
+
+type GitHubNotifier struct {
+	deployments map[int]*GitHubDeployment
+	mutex       *sync.Mutex
+}
+
+func NewGitHubNotifier() *GitHubNotifier {
+	return &GitHubNotifier{
+		deployments: make(map[int]*GitHubDeployment),
+		mutex:       &sync.Mutex{},
+	}
+}
+
+func (notifier *GitHubNotifier) Notify(ev *DeploymentEvent) {
+	notifier.mutex.Lock()
+	defer notifier.mutex.Unlock()
+
+	ghClient := NewGitHubClient(ev.User)
+
+	if ev.State == models.DEPLOYMENT_NEW {
+		githubDeployment, err := ghClient.CreateDeployment(ev.Application, ev.Deployment)
+		if err != nil {
+			log.Printf("Creating GitHub deployment failed: %s\n", err)
+			return
+		}
+		notifier.deployments[ev.Deployment.Id] = githubDeployment
+	} else {
+		githubDeployment, ok := notifier.deployments[ev.Deployment.Id]
+		if !ok {
+			log.Printf("No GitHubDeployment for %d found\n", ev.Deployment.Id)
+			return
+		}
+		err := ghClient.CreateDeploymentStatus(githubDeployment, ev.State)
+		if err != nil {
+			log.Printf("Creating GitHub deployment status failed: %s\n", err)
+			return
+		}
+	}
+}

--- a/server/main.go
+++ b/server/main.go
@@ -174,6 +174,16 @@ func main() {
 		models.DEPLOYMENT_FAILED,
 	}
 	eventHub.Subscribe(slackStates, NotifySlack)
+	// Subscribe the GitHub notifier to use the Deployments API
+	githubNotifier := NewGitHubNotifier()
+	githubStates := []models.DeploymentState{
+		models.DEPLOYMENT_NEW,
+		models.DEPLOYMENT_ACTIVE,
+		models.DEPLOYMENT_SUCCESSFUL,
+		models.DEPLOYMENT_FAILED,
+	}
+	eventHub.Subscribe(githubStates, githubNotifier.Notify)
+
 	// Subscribe the webhooks
 	webhookStates := []models.DeploymentState{
 		models.DEPLOYMENT_NEW,

--- a/server/notifier_summary.go
+++ b/server/notifier_summary.go
@@ -10,22 +10,12 @@ import (
 )
 
 func generateSummary(t *template.Template, ev *DeploymentEvent) (string, error) {
-	var scheme string
-	if config.SSLEnabled {
-		scheme = "https"
-	} else {
-		scheme = "http"
-	}
-
 	var success bool
 	if ev.State == models.DEPLOYMENT_SUCCESSFUL {
 		success = true
 	} else {
 		success = false
 	}
-
-	deploymentUrl := fmt.Sprintf("%s://%s/%v/deployments/%v", scheme, config.Host,
-		ev.Application.GitHubRepo, ev.Deployment.Id)
 
 	gitHubUrl := fmt.Sprintf("https://github.com/%v/%v/commit/%v",
 		ev.Application.GitHubOwner, ev.Application.GitHubRepo,
@@ -41,7 +31,7 @@ func generateSummary(t *template.Template, ev *DeploymentEvent) (string, error) 
 		"Comment":       ev.Deployment.Comment,
 		"CommentLines":  strings.Split(ev.Deployment.Comment, "\n"),
 		"GitHubUrl":     gitHubUrl,
-		"DeploymentURL": deploymentUrl,
+		"DeploymentURL": ev.DeploymentURL(),
 	})
 
 	return summary.String(), err

--- a/server/webhook_notifier.go
+++ b/server/webhook_notifier.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -54,14 +53,6 @@ func NotifyWebhooks(ev *DeploymentEvent) {
 		return
 	}
 
-	scheme := "http"
-	if config.SSLEnabled {
-		scheme = "https"
-	}
-
-	deploymentUrl := fmt.Sprintf("%s://%s/%v/deployments/%v",
-		scheme, config.Host, ev.Application.GitHubRepo, ev.Deployment.Id)
-
 	msg := WebhookMsg{
 		Timestamp: time.Now(),
 		State:     ev.State,
@@ -77,7 +68,7 @@ func NotifyWebhooks(ev *DeploymentEvent) {
 			State:          ev.Deployment.State,
 			Comment:        ev.Deployment.Comment,
 			CreatedAt:      ev.Deployment.CreatedAt,
-			URL:            deploymentUrl,
+			URL:            ev.DeploymentURL(),
 			DeployerID:     ev.Deployment.UserId,
 			DeployerName:   ev.Deployment.User.Name,
 			DeployerAvatar: ev.Deployment.User.AvatarUrl,


### PR DESCRIPTION
This adds support for the GitHub Deployments API. Applikatoni now tells GitHub about ongoing and finished deployments, which is visible in Pull Requests. Examples:

**New deployment**:
![deployment_api_1](https://cloud.githubusercontent.com/assets/1185253/13740488/53949454-e9d1-11e5-8e2f-4fa31229458a.png)
**Status of deployment updated to "pending"**:
![deployments_api_2](https://cloud.githubusercontent.com/assets/1185253/13740490/55ad1fb8-e9d1-11e5-9602-eacb7d7570d1.png)
**Status of deployment updated to "success"**:
![deployment_api_3](https://cloud.githubusercontent.com/assets/1185253/13740492/57fd3654-e9d1-11e5-821d-f7baac95f025.png)

I also added the URL helper `DeploymentURL()` to `DeploymentEvent`. That saves code and removes the URL building from two other files, but I'm still not sure if it's the best place. We should have a central place for URL generation.