### PR TITLE
Update AccessToken and AvatarUrl on re-authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Store new GitHub access token in case the previous token has been revoked and
+  the user re-authenticates. (nlochschmidt)
 * Fix the "deployment already in progress" check. The check was wrong, since it
   did not take the application that's being deployed into account, only the
   target. (mrnugget)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -467,7 +467,7 @@ func oauth2callbackHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = getOrCreateUser(db, user)
+	err = createOrUpdateUser(db, user)
 	if err != nil {
 		log.Println("insertUser failed", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)


### PR DESCRIPTION
Decided against updating the Name and ApiToken as well because I believe
those are not allowed to change.

Closes #40 